### PR TITLE
Modification of styles

### DIFF
--- a/Projection.js
+++ b/Projection.js
@@ -93,9 +93,9 @@ define([
             this.projectionStore = new ItemFileWriteStore({ data: data });
 
             var layout = [
-               { 'name': 'Name', 'field': 'name', 'width': '100px', 'noresize': 'true', styles: 'bold;text-align: right;' },
-               { 'name': 'x', 'field': 'x', 'width': '88px', 'noresize': 'true', 'editable': 'true', styles: 'text-align: right;' },
-               { 'name': 'y', 'field': 'y', 'width': '89px', 'noresize': 'true', 'editable': 'true', styles: 'text-align: right;' }
+               { 'name': 'Name', 'field': 'name', 'width': '24%', 'noresize': 'true', styles: 'bold;text-align: left;' },
+               { 'name': 'x', 'field': 'x', 'width': '38%', 'noresize': 'true', 'editable': 'true', styles: 'text-align: left;' },
+               { 'name': 'y', 'field': 'y', 'width': '38%', 'noresize': 'true', 'editable': 'true', styles: 'text-align: left;' }
             ];
 
             this.projectionGrid = new DataGrid({

--- a/Projection/css/Projection.css
+++ b/Projection/css/Projection.css
@@ -1,6 +1,8 @@
 .gis-ProjectionDijit {
     overflow: hidden;
     font-size: 90%;
+	vertical-align: middle;
+	width: 100% !important;
 }
 
 .gis-ProjectionDijit .locateIcon {
@@ -19,4 +21,51 @@
     background-image: url(../images/zoom.png);
     width: 16px;
     height: 16px;
+}
+
+/* Override of widget styles (!important tag used to overide .js style in jsapi) */
+
+.gis-ProjectionDijit .dojoxGridRow tr {
+  background-color: #FFFFFF;
+  color: #666666;
+  border-color: #DDD #DDD #DDD #DDD;
+  font-size: 14px;
+}
+
+.gis-ProjectionDijit .dojoxGridHeader{
+width: 100% !important;
+left: 0px !important
+}
+
+.gis-ProjectionDijit .dojoxGridHeader div{
+width: 100% !important
+}
+
+.gis-ProjectionDijit .dojoxGridHeader .dojoxGridCell {
+  background-image: none !important;
+  background-color: #F5F5F5 !important;
+  border-color: #DDD #DDD #DDD #DDD;
+}
+
+.gis-ProjectionDijit .dojoxGridHeader .dojoxGridCell div {
+  color: #666666;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.gis-ProjectionDijit .dojoxGridView {
+width: 100% !important;
+left: 0px !important
+}
+
+.gis-ProjectionDijit .dojoxGridView  div{
+width: 100% !important
+}
+
+.gis-ProjectionDijit .dojoxGridRowTable {
+width: 100% !important
+}
+
+.gis-ProjectionDijit .dojoxGridContent div{
+width: 100% !important
 }


### PR DESCRIPTION
A change of style of the widget to be in line with that of the rest of
the CMV Viewer, including the forcing of 100% width for use when the app
resizes due to scroll bars.

The <code>!important</code> tag was used to force CSS styling over the .js of the JSAPI

Original
![image](https://cloud.githubusercontent.com/assets/8898008/4591498/d1575c86-506d-11e4-92fe-73f06d365e15.png)

Original with scroll bar
![image](https://cloud.githubusercontent.com/assets/8898008/4591597/2429fbe8-506f-11e4-988b-9ec7cf973a98.png)

Re-styled (the point marker was modified for personal preference)
![image](https://cloud.githubusercontent.com/assets/8898008/4591509/f2a82816-506d-11e4-8e70-490801d1bf42.png)

Re-styled with scroll bar
![image](https://cloud.githubusercontent.com/assets/8898008/4591586/04452b9a-506f-11e4-9338-c33ba3b0146d.png)
